### PR TITLE
feat: Distinguish enable/disable module states for Delay transaction

### DIFF
--- a/test/profileDelayedTransaction.spec.ts
+++ b/test/profileDelayedTransaction.spec.ts
@@ -3,9 +3,11 @@ import { ZeroAddress } from "ethers";
 import hre from "hardhat";
 
 import { createInnerLimitTransaction } from "../src";
+import deployments from "../src/deployments";
 import profileDelayedTransaction, {
   DelayedTransactionType,
 } from "../src/entrypoints/profileDelayedTransaction";
+import { predictDelayModAddress } from "../src/parts";
 import { IERC20__factory } from "../typechain-types";
 
 const AddressOne = "0x0000000000000000000000000000000000000001";
@@ -52,6 +54,7 @@ describe("profileDelayedTransaction", () => {
       })
     ).to.not.equal(DelayedTransactionType.ERC20Transfer);
   });
+
   it("identifies a limit transaction", async () => {
     const [account] = await hre.ethers.getSigners();
 
@@ -78,5 +81,75 @@ describe("profileDelayedTransaction", () => {
         data: `0x${transaction.data.slice(4)}`,
       })
     ).to.not.equal(DelayedTransactionType.LimitChange);
+  });
+
+  it("identifies enableModule transaction if the `to` address is a Delay Module", async () => {
+    const [account] = await hre.ethers.getSigners();
+
+    const iface = deployments.rolesModMastercopy.iface;
+    const data = iface.encodeFunctionData("enableModule", [account.address]);
+
+    const delayModuleAddressForAccount = predictDelayModAddress(
+      account.address
+    );
+
+    expect(
+      profileDelayedTransaction(account.address, {
+        to: delayModuleAddressForAccount,
+        data,
+      })
+    ).to.equal(DelayedTransactionType.AddOwner);
+  });
+
+  it("does not identify enableModule transaction if the `to` address is not a Delay Module", async () => {
+    const [account] = await hre.ethers.getSigners();
+
+    const iface = deployments.delayModMastercopy.iface;
+    const data = iface.encodeFunctionData("enableModule", [account.address]);
+
+    expect(
+      profileDelayedTransaction(account.address, {
+        to: ZeroAddress,
+        data,
+      })
+    ).to.equal(DelayedTransactionType.Other);
+  });
+
+  it("identifies disableModule transaction if the `to` address is a Delay Module", async () => {
+    const [account] = await hre.ethers.getSigners();
+
+    const iface = deployments.delayModMastercopy.iface;
+    const data = iface.encodeFunctionData("disableModule", [
+      account.address,
+      AddressOne,
+    ]);
+
+    const delayModuleAddressForAccount = predictDelayModAddress(
+      account.address
+    );
+
+    expect(
+      profileDelayedTransaction(account.address, {
+        to: delayModuleAddressForAccount,
+        data,
+      })
+    ).to.equal(DelayedTransactionType.RemoveOwner);
+  });
+
+  it("does not identify disableModule transaction if the `to` address is not a Delay Module", async () => {
+    const [account] = await hre.ethers.getSigners();
+
+    const iface = deployments.delayModMastercopy.iface;
+    const data = iface.encodeFunctionData("disableModule", [
+      account.address,
+      AddressOne,
+    ]);
+
+    expect(
+      profileDelayedTransaction(account.address, {
+        to: ZeroAddress,
+        data,
+      })
+    ).to.equal(DelayedTransactionType.Other);
   });
 });


### PR DESCRIPTION
This PR adds two new distinct states for profiling the delay transaction:
- enableModule
- disableModule

Conditions to meet to get to these 2 states are:
- that the `to` address matches the `delay module` address of the account that the operation is being executed on
- that the fn name is one of the 2 above

<img width="584" alt="image" src="https://github.com/gnosispay/account-kit/assets/163864960/c7a0581a-ce98-43d2-984c-4aac4f2707ad">
