### PR TITLE
feat: Implement account removal utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosispay/account-kit",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "author": "cristovao.honorato@gnosis.io",
   "main": "dist/cjs/src/index.js",
   "module": "dist/esm/src/index.js",

--- a/src/entrypoints/accounts-actions/addAccountOwner.ts
+++ b/src/entrypoints/accounts-actions/addAccountOwner.ts
@@ -1,0 +1,179 @@
+import { getAddress } from "ethers";
+import { HexString } from "ethers/lib.commonjs/utils/data";
+import {
+  populateExecuteDispatch,
+  populateExecuteEnqueue,
+  saltFromTimestamp,
+} from "./execute";
+import deployments from "../../deployments";
+import { predictDelayModAddress } from "../../parts";
+import { SignTypedDataCallback, TransactionRequest } from "../../types";
+
+export const SENTINEL_ADDRESS = "0x0000000000000000000000000000000000000001";
+
+type EnqueueParameters = {
+  /**
+   * The address of the account
+   */
+  account: string;
+  /*
+   * ID associated with the current network.
+   */
+  chainId: number;
+  /*
+   * An optional bytes32 string that will be used for signature replay protection
+   * (Should be omitted, and in that case, a random salt will be generated)
+   */
+  salt?: string;
+};
+
+type DispatchParameters = {
+  /**
+   * The address of the account
+   */
+  account: string;
+};
+
+/**
+ * This function generates a payload to initiate an addition of the account owner in
+ * Delay Mod's queue. The populated transaction is relay ready, and does not
+ * require additional signing.
+ *
+ * @param parameters - {@link EnqueueParameters}
+ * @param newOwner - {@link `0x${string}`}
+ * @param sign - {@link SignTypedDataCallback}
+ * @returns The signed transaction payload {@link TransactionRequest}
+ *
+ * @example
+ * import { populateAddOwnerEnqueue } from "@gnosispay/account-kit";
+ *
+ * const owner: Signer = {};
+ * const enqueueTx = await populateAddOwnerEnqueue(
+ *  { account: `0x<address>`, chainId: `<number>` },
+ *  newOwner: `0x${string}`,
+ *  // callback that wraps an eip-712 signature
+ *  ({ domain, primaryType, types, message }) =>
+ *    owner.signTypedData(domain, primaryType, types, message)
+ * );
+ * await relayer.sendTransaction(enqueueTx);
+ */
+export async function populateAddOwnerEnqueue(
+  { account, chainId, salt }: EnqueueParameters,
+  newOwner: `0x${string}`,
+  sign: SignTypedDataCallback
+): Promise<TransactionRequest> {
+  account = getAddress(account);
+  salt = salt || saltFromTimestamp();
+
+  return populateExecuteEnqueue(
+    { account, chainId, salt },
+    createInnerTransaction(account, newOwner),
+    sign
+  );
+}
+
+/**
+ * Generates a payload that executes an allowance change previously posted to
+ * the Delay Mod. Only works after cooldown seconds and have passed, and before
+ * expiration. The populated transaction is relay ready, and does not require
+ * additional signing.
+ *
+ * @param parameters - {@link DispatchParameters}
+ * @param transaction - {@link AllowanceConfig}
+ * @returns The signed transaction payload {@link TransactionRequest}
+ *
+ * @example
+ * import { populateAddOwnerDispatch } from "@gnosispay/account-kit";
+ *
+ * const dispatchTx = await populateAddOwnerDispatch(
+ *  { account: `0x<address>` },
+ *  newOwner: `0x${string}`,
+ * );
+ * await relayer.sendTransaction(enqueueTx);
+ */
+export function populateAddOwnerDispatch(
+  { account }: DispatchParameters,
+  newOwner: `0x${string}`
+): TransactionRequest {
+  account = getAddress(account);
+
+  return populateExecuteDispatch(
+    { account },
+    createInnerTransaction(account, newOwner)
+  );
+}
+
+export function createInnerTransaction(
+  account: string,
+  newOwner: `0x${string}`
+): TransactionRequest {
+  const delayMod = {
+    address: predictDelayModAddress(account),
+    iface: deployments.delayModMastercopy.iface,
+  };
+
+  return {
+    to: delayMod.address,
+    data: delayMod.iface.encodeFunctionData("enableModule", [newOwner]),
+    value: 0,
+  };
+}
+
+type EthCallCallback = (
+  encodedFunctionCall: `0x${string}`
+) => Promise<{ data: HexString | undefined }>;
+
+export async function getAccountOwners(
+  doEthCall: EthCallCallback,
+  from: `0x${string}` = SENTINEL_ADDRESS
+): Promise<`0x${string}`[]> {
+  const FETCH_COUNT = 100;
+
+  const delayMod = {
+    iface: deployments.delayModMastercopy.iface,
+  };
+
+  const calldata = delayMod.iface.encodeFunctionData("getModulesPaginated", [
+    from,
+    FETCH_COUNT,
+  ]) as `0x${string}`;
+
+  const ethResult = await doEthCall(calldata);
+
+  if (!ethResult.data) {
+    throw new Error("No data returned from eth call");
+  }
+
+  const [addresses] = delayMod.iface.decodeFunctionResult(
+    "getModulesPaginated",
+    ethResult.data
+  );
+
+  return [
+    ...addresses,
+    ...(addresses.length < FETCH_COUNT
+      ? []
+      : await getAccountOwners(doEthCall, addresses[addresses.length - 1])),
+  ];
+}
+
+export function removeAccountOwner(
+  account: string,
+  {
+    previousLastAccountOwner,
+    accountToRemove,
+  }: {
+    previousLastAccountOwner: string;
+    accountToRemove: string;
+  }
+) {
+  const delayMod = {
+    address: predictDelayModAddress(account),
+    iface: deployments.delayModMastercopy.iface,
+  };
+
+  return delayMod.iface.encodeFunctionData("disableModule", [
+    previousLastAccountOwner,
+    accountToRemove,
+  ]);
+}

--- a/src/entrypoints/accounts-actions/getAccountOwners.ts
+++ b/src/entrypoints/accounts-actions/getAccountOwners.ts
@@ -1,0 +1,64 @@
+import { HexString } from "ethers/lib.commonjs/utils/data";
+import deployments from "../../deployments";
+import { predictDelayModAddress } from "../../parts";
+
+export const SENTINEL_ADDRESS = "0x0000000000000000000000000000000000000001";
+
+type EthCallCallback = (
+  encodedFunctionCall: `0x${string}`
+) => Promise<{ data: HexString | undefined }>;
+
+export async function getAccountOwners(
+  doEthCall: EthCallCallback,
+  from: `0x${string}` = SENTINEL_ADDRESS
+): Promise<`0x${string}`[]> {
+  const FETCH_COUNT = 100;
+
+  const delayMod = {
+    iface: deployments.delayModMastercopy.iface,
+  };
+
+  const calldata = delayMod.iface.encodeFunctionData("getModulesPaginated", [
+    from,
+    FETCH_COUNT,
+  ]) as `0x${string}`;
+
+  const ethResult = await doEthCall(calldata);
+
+  if (!ethResult.data) {
+    throw new Error("No data returned from eth call");
+  }
+
+  const [addresses] = delayMod.iface.decodeFunctionResult(
+    "getModulesPaginated",
+    ethResult.data
+  );
+
+  return [
+    ...addresses,
+    ...(addresses.length < FETCH_COUNT
+      ? []
+      : await getAccountOwners(doEthCall, addresses[addresses.length - 1])),
+  ];
+}
+
+export function removeAccountOwner(
+  account: string,
+  {
+    previousLastAccountOwner,
+    accountToRemove,
+  }: {
+    previousLastAccountOwner: string;
+    accountToRemove: string;
+  }
+) {
+  const delayMod = {
+    address: predictDelayModAddress(account),
+    iface: deployments.delayModMastercopy.iface,
+  };
+
+  return delayMod.iface.encodeFunctionData("disableModule", [
+    previousLastAccountOwner,
+    accountToRemove,
+  ]);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
 import populateAccountCreation, {
   populateDirectTransfer,
 } from "./entrypoints/accounts-actions/accountCreation";
+import accountQuery from "./entrypoints/accounts-actions/accountQuery";
+import populateAccountSetup from "./entrypoints/accounts-actions/accountSetup";
 import {
   getAccountOwners,
   createInnerTransaction as createInnerAddOwnerTransaction,
-} from "./entrypoints/accounts-actions/accountOwner";
-import accountQuery from "./entrypoints/accounts-actions/accountQuery";
-import populateAccountSetup from "./entrypoints/accounts-actions/accountSetup";
+} from "./entrypoints/accounts-actions/addAccountOwner";
 import {
   populateExecuteEnqueue,
   populateExecuteDispatch,
@@ -16,6 +16,7 @@ import {
   populateLimitDispatch,
   createInnerTransaction as createInnerLimitTransaction,
 } from "./entrypoints/accounts-actions/limit";
+import { createInnerTransaction as createInnerRemoveOwnerTransaction } from "./entrypoints/accounts-actions/removeAccountOwner";
 import populateSpend from "./entrypoints/accounts-actions/spend";
 
 import {
@@ -48,4 +49,5 @@ export {
   DelayedTransactionType,
   getAccountOwners,
   createInnerAddOwnerTransaction,
+  createInnerRemoveOwnerTransaction,
 };

--- a/test/addAccountOwner.ts
+++ b/test/addAccountOwner.ts
@@ -1,0 +1,126 @@
+import { loadFixture, mine } from "@nomicfoundation/hardhat-network-helpers";
+import { expect } from "chai";
+import { getAddress } from "ethers";
+import hre from "hardhat";
+import { createSetupConfig, postFixture, preFixture } from "./test-helpers";
+import {
+  populateAccountCreation,
+  populateAccountSetup,
+  predictAccountAddress,
+} from "../src";
+import {
+  SENTINEL_ADDRESS,
+  populateAddOwnerDispatch,
+  populateAddOwnerEnqueue,
+} from "../src/entrypoints/accounts-actions/addAccountOwner";
+import { predictDelayModAddress } from "../src/parts";
+import { IDelayModifier__factory } from "../typechain-types";
+
+const PERIOD = 12345;
+const AMOUNT = 76543;
+const COOLDOWN = 120;
+
+describe("addAccountOwner", () => {
+  before(async () => {
+    await preFixture();
+  });
+
+  after(async () => {
+    await postFixture();
+  });
+
+  async function setupAccount() {
+    const [owner, spender, receiver, relayer] = await hre.ethers.getSigners();
+
+    const erc20 = await (
+      await hre.ethers.getContractFactory("TestERC20")
+    ).deploy();
+
+    const config = createSetupConfig({
+      spender: spender.address,
+      receiver: receiver.address,
+      period: PERIOD,
+      token: await erc20.getAddress(),
+      allowance: AMOUNT,
+      cooldown: COOLDOWN,
+    });
+    const account = predictAccountAddress({ owner: owner.address });
+
+    const creationTx = populateAccountCreation({ owner: owner.address });
+    const setupTx = await populateAccountSetup(
+      { owner: owner.address, account, chainId: 31337, nonce: 0 },
+      config,
+      ({ domain, types, message }) =>
+        owner.signTypedData(domain, types, message)
+    );
+
+    await relayer.sendTransaction(creationTx);
+    await relayer.sendTransaction(setupTx);
+
+    return {
+      account,
+      owner,
+      spender,
+      receiver,
+      relayer,
+      delayMod: IDelayModifier__factory.connect(
+        predictDelayModAddress(account),
+        relayer
+      ),
+      config,
+    };
+  }
+
+  it("adds an account owner", async () => {
+    const { account, owner, relayer, delayMod } =
+      await loadFixture(setupAccount);
+
+    const firstOwner = owner.address;
+    const secondOwner = getAddress(
+      "0x06b2729304C9c15CB1bA2df761455e474080CA19"
+    ) as `0x${string}`;
+    const enqueueTx = await populateAddOwnerEnqueue(
+      { account, chainId: 31337 },
+      secondOwner,
+      ({ domain, types, message }) =>
+        owner.signTypedData(domain, types, message)
+    );
+    const executeTx = populateAddOwnerDispatch({ account }, secondOwner);
+
+    {
+      // starts correctly configured
+      const [owners] = await delayMod.getModulesPaginated(
+        SENTINEL_ADDRESS,
+        100
+      );
+      expect(owners).to.deep.equal([firstOwner]);
+      // the owner of the delay mod is the safe
+      expect(await delayMod.owner()).to.equal(account);
+    }
+
+    // dispatch the enqueue tx
+    await relayer.sendTransaction(enqueueTx);
+
+    {
+      // no changes on owners yet, only enqueued
+      const [owners] = await delayMod.getModulesPaginated(
+        SENTINEL_ADDRESS,
+        100
+      );
+      expect(owners).to.deep.equal([firstOwner]);
+    }
+
+    // we try to send the dispatch tx, but gets reverted before cooldown
+    await expect(relayer.sendTransaction(executeTx)).to.be.revertedWith(
+      "Transaction is still in cooldown"
+    );
+    await mine(2, { interval: 120 });
+
+    // works after cooldown
+    await expect(relayer.sendTransaction(executeTx)).to.not.be.reverted;
+
+    // second owner is now reflected
+    const [owners] = await delayMod.getModulesPaginated(SENTINEL_ADDRESS, 100);
+    expect(owners).to.deep.equal([secondOwner, owner.address]);
+  });
+});

--- a/test/removeAccountOwner.spec.ts
+++ b/test/removeAccountOwner.spec.ts
@@ -1,0 +1,154 @@
+import { loadFixture, mine } from "@nomicfoundation/hardhat-network-helpers";
+import { expect } from "chai";
+import { getAddress } from "ethers";
+import hre from "hardhat";
+import { createSetupConfig, postFixture, preFixture } from "./test-helpers";
+import {
+  populateAccountCreation,
+  populateAccountSetup,
+  predictAccountAddress,
+} from "../src";
+import {
+  populateAddOwnerDispatch,
+  populateAddOwnerEnqueue,
+} from "../src/entrypoints/accounts-actions/addAccountOwner";
+import {
+  SENTINEL_ADDRESS,
+  populateRemoveOwnerEnqueue,
+  populateRemoveOwnerDispatch,
+} from "../src/entrypoints/accounts-actions/removeAccountOwner";
+import { predictDelayModAddress } from "../src/parts";
+import { IDelayModifier__factory } from "../typechain-types";
+
+const PERIOD = 12345;
+const AMOUNT = 76543;
+const COOLDOWN = 120;
+
+describe("removeAccountOwner", () => {
+  before(async () => {
+    await preFixture();
+  });
+
+  after(async () => {
+    await postFixture();
+  });
+
+  async function setupAccount() {
+    const [owner, spender, receiver, relayer] = await hre.ethers.getSigners();
+
+    const erc20 = await (
+      await hre.ethers.getContractFactory("TestERC20")
+    ).deploy();
+
+    const config = createSetupConfig({
+      spender: spender.address,
+      receiver: receiver.address,
+      period: PERIOD,
+      token: await erc20.getAddress(),
+      allowance: AMOUNT,
+      cooldown: COOLDOWN,
+    });
+    const account = predictAccountAddress({ owner: owner.address });
+
+    const creationTx = populateAccountCreation({ owner: owner.address });
+    const setupTx = await populateAccountSetup(
+      { owner: owner.address, account, chainId: 31337, nonce: 0 },
+      config,
+      ({ domain, types, message }) =>
+        owner.signTypedData(domain, types, message)
+    );
+
+    await relayer.sendTransaction(creationTx);
+    await relayer.sendTransaction(setupTx);
+
+    return {
+      account,
+      owner,
+      spender,
+      receiver,
+      relayer,
+      delayMod: IDelayModifier__factory.connect(
+        predictDelayModAddress(account),
+        relayer
+      ),
+      config,
+    };
+  }
+
+  it("removes an account owner", async () => {
+    const { account, owner, relayer, delayMod } =
+      await loadFixture(setupAccount);
+
+    const firstOwner = owner.address;
+    const secondOwner = getAddress(
+      "0x06b2729304C9c15CB1bA2df761455e474080CA19"
+    ) as `0x${string}`;
+
+    {
+      // starts correctly configured
+      const [owners] = await delayMod.getModulesPaginated(
+        SENTINEL_ADDRESS,
+        100
+      );
+      expect(owners).to.deep.equal([firstOwner]);
+      // the owner of the delay mod is the safe
+      expect(await delayMod.owner()).to.equal(account);
+    }
+
+    // add a new owner
+    await relayer.sendTransaction(
+      await populateAddOwnerEnqueue(
+        { account, chainId: 31337 },
+        secondOwner,
+        ({ domain, types, message }) =>
+          owner.signTypedData(domain, types, message)
+      )
+    );
+    await mine(2, { interval: 120 });
+    await relayer.sendTransaction(
+      populateAddOwnerDispatch({ account }, secondOwner)
+    );
+
+    {
+      const [owners] = await delayMod.getModulesPaginated(
+        SENTINEL_ADDRESS,
+        100
+      );
+      expect(owners).to.deep.equal([secondOwner, owner.address]);
+    }
+
+    const enqueueTx = await populateRemoveOwnerEnqueue(
+      { account, chainId: 31337 },
+      {
+        prevOwner: secondOwner,
+        ownerToRemove: owner.address,
+      },
+      ({ domain, types, message }) =>
+        owner.signTypedData(domain, types, message)
+    );
+
+    const executeTx = populateRemoveOwnerDispatch(
+      { account },
+      {
+        prevOwner: secondOwner,
+        ownerToRemove: owner.address,
+      }
+    );
+
+    // dispatch the enqueue tx
+    await relayer.sendTransaction(enqueueTx);
+
+    // we try to send the dispatch tx, but gets reverted before cooldown
+    await expect(relayer.sendTransaction(executeTx)).to.be.revertedWith(
+      "Transaction is still in cooldown"
+    );
+    await mine(2, { interval: 120 });
+
+    // works after cooldown
+    await expect(relayer.sendTransaction(executeTx)).to.not.be.reverted;
+
+    // second owner is now removed
+    const [owners] = await delayMod.getModulesPaginated(SENTINEL_ADDRESS, 100);
+    expect(owners).to.deep.equal([secondOwner]);
+  });
+});


### PR DESCRIPTION
This PR adds ability of triggering a `disableModule` call in order to remove a signer/owner of the account.