### PR TITLE
Export 2 inner functions to be used externally by a back-end. 

### DIFF
--- a/src/entrypoints/accounts-actions/execute.ts
+++ b/src/entrypoints/accounts-actions/execute.ts
@@ -34,6 +34,21 @@ type DispatchParameters = {
 };
 
 /**
+ * Helper function to encode transaction data for the delay modifier
+ */
+function encodeDelayModTransaction(transaction: TransactionRequest): string {
+  return deployments.delayModMastercopy.iface.encodeFunctionData(
+    "execTransactionFromModule",
+    [
+      transaction.to,
+      transaction.value || 0,
+      transaction.data,
+      transaction.operationType ?? OperationType.Call,
+    ]
+  );
+}
+
+/**
  * Generates a payload that wraps a transaction, and posts it to the Delay Mod
  * queue. The populated transaction is relay ready, and does not require
  * additional signing.
@@ -61,35 +76,109 @@ export async function populateExecuteEnqueue(
   transaction: TransactionRequest,
   sign: SignTypedDataCallback
 ): Promise<TransactionRequest> {
-  account = getAddress(account);
-  salt = salt || saltFromTimestamp();
-
-  const delayMod = {
-    address: predictDelayModAddress(account),
-    iface: deployments.delayModMastercopy.iface,
-  };
-
-  const { to, value, data } = {
-    to: delayMod.address,
-    value: 0,
-    data: delayMod.iface.encodeFunctionData("execTransactionFromModule", [
-      transaction.to,
-      transaction.value || 0,
-      transaction.data,
-      transaction.operationType ?? OperationType.Call,
-    ]),
-  };
-
-  const { domain, primaryType, types, message } =
-    typedDataForModifierTransaction(
-      { modifier: delayMod.address, chainId },
-      { data, salt }
-    );
+  const { domain, primaryType, types, message } = generateTypedData(
+    { account, chainId, salt },
+    transaction
+  );
 
   const signature = await sign({ domain, primaryType, types, message });
 
-  return { to, value, data: concat([data, salt, signature]) };
+  const txRequest = getTransactionRequest({
+    account,
+    transaction,
+    message,
+    signature,
+  });
+
+  return txRequest;
 }
+
+/**
+ * Constructs the final transaction request for executing a queued transaction
+ * on the Delay Modifier. This function combines the encoded transaction data
+ * with the salt and signature to create a relay-ready transaction.
+ *
+ * @param parameters - Object containing account, transaction, message, and signature
+ * @param parameters.account - The address of the account Safe
+ * @param parameters.transaction - The original transaction to be executed
+ * @param parameters.message - The message object containing salt and data from typed data generation
+ * @param parameters.signature - The EIP-712 signature from the account owner
+ * @returns The complete transaction request ready for relay execution
+ *
+ * @example
+ * import { getTransactionRequest } from "@gnosispay/account-kit";
+ *
+ * const txRequest = getTransactionRequest({
+ *   account: "0x<address>",
+ *   transaction: { to: "0x<address>", value: 0n, data: "0x<bytes>" },
+ *   message: { salt: "0x<bytes32>", data: "0x<encoded_data>" },
+ *   signature: "0x<signature>"
+ * });
+ */
+export const getTransactionRequest = ({
+  account,
+  transaction,
+  message,
+  signature,
+}: {
+  account: string;
+  transaction: TransactionRequest;
+  message: {
+    salt: string;
+    data: string;
+  };
+  signature: string;
+}) => {
+  const checkSumedAccount = getAddress(account);
+  const delayModAddress = predictDelayModAddress(checkSumedAccount);
+  const encodedData = encodeDelayModTransaction(transaction);
+
+  return {
+    to: delayModAddress,
+    value: 0,
+    data: concat([encodedData, message.salt, signature]),
+  };
+};
+
+/**
+ * Generates EIP-712 typed data for a transaction that will be queued in the
+ * Delay Modifier. This function prepares all the necessary components for
+ * signature generation without executing the transaction.
+ *
+ * @param parameters - Object containing account, chainId, and optional salt
+ * @param parameters.account - The address of the account Safe
+ * @param parameters.chainId - ID associated with the current network
+ * @param parameters.salt - Optional bytes32 string for signature replay protection (random if omitted)
+ * @param transaction - The transaction to be queued for delayed execution
+ * @returns Object containing domain, primaryType, types, and message for EIP-712 signing
+ *
+ * @example
+ * import { generateTypedData } from "@gnosispay/account-kit";
+ *
+ * const typedData = generateTypedData(
+ *   { account: "0x<address>", chainId: 1 },
+ *   { to: "0x<address>", value: 0n, data: "0x<bytes>" }
+ * );
+ * // Send typedData to frontend for user signature
+ */
+export const generateTypedData = (
+  { account, chainId, salt }: EnqueueParameters,
+  transaction: TransactionRequest
+) => {
+  const checkSumedAccount = getAddress(account);
+  salt = salt || saltFromTimestamp();
+
+  const delayModAddress = predictDelayModAddress(checkSumedAccount);
+  const encodedData = encodeDelayModTransaction(transaction);
+
+  const { domain, primaryType, types, message } =
+    typedDataForModifierTransaction(
+      { modifier: delayModAddress, chainId },
+      { data: encodedData, salt }
+    );
+
+  return { domain, primaryType, types, message };
+};
 
 /**
  * Generates a payload that executes a transaction previously posted to the
@@ -133,6 +222,18 @@ export function populateExecuteDispatch(
   };
 }
 
+/**
+ * Generates a timestamp-based salt value encoded as bytes32 for use in
+ * transaction replay protection. Uses the current timestamp in milliseconds.
+ *
+ * @returns A bytes32 encoded timestamp suitable for use as a salt parameter
+ *
+ * @example
+ * import { saltFromTimestamp } from "@gnosispay/account-kit";
+ *
+ * const salt = saltFromTimestamp();
+ * // Use salt in generateTypedData or other functions requiring replay protection
+ */
 export function saltFromTimestamp() {
   return AbiCoder.defaultAbiCoder().encode(["uint256"], [Date.now()]);
 }

--- a/src/entrypoints/accounts-actions/execute.ts
+++ b/src/entrypoints/accounts-actions/execute.ts
@@ -83,14 +83,12 @@ export async function populateExecuteEnqueue(
 
   const signature = await sign({ domain, primaryType, types, message });
 
-  const txRequest = getTransactionRequest({
+  return getTransactionRequest({
     account,
     transaction,
     message,
     signature,
   });
-
-  return txRequest;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ import {
 import {
   populateExecuteEnqueue,
   populateExecuteDispatch,
+  getTransactionRequest,
+  generateTypedData,
 } from "./entrypoints/accounts-actions/execute";
 import {
   populateLimitEnqueue,
@@ -41,6 +43,8 @@ export {
   populateAccountSetup,
   populateExecuteDispatch,
   populateExecuteEnqueue,
+  generateTypedData,
+  getTransactionRequest,
   populateLimitDispatch,
   populateLimitEnqueue,
   populateSpend,


### PR DESCRIPTION
Closes https://linear.app/gnosis-pay/issue/ENG-2788/expose-inner-functions-from-populateexecuteenqueue-in-the-account-kit


The idea is to be able to execute the same behavior as `populateExecuteEnqueue` from a back-end by calling `generateTypedData`, then letting the user sign the data, then calling `getTransactionRequest` together with the signed data.