### PR TITLE
Add ERC1271 support

### DIFF
--- a/contracts/test/MockERC1271Wallet.sol
+++ b/contracts/test/MockERC1271Wallet.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+/**
+ * @title RealERC1271Wallet
+ * @dev A real ERC1271 wallet that validates actual ECDSA signatures
+ * This wallet validates signatures against its owner's address using ECDSA recovery
+ */
+contract RealERC1271Wallet {
+    using ECDSA for bytes32;
+    
+    // ERC1271 magic value
+    bytes4 constant internal MAGICVALUE = 0x1626ba7e;
+    bytes4 constant internal INVALID_SIGNATURE = 0xffffffff;
+    
+    // Owner of this wallet
+    address public owner;
+    
+    constructor(address _owner) {
+        owner = _owner;
+    }
+    
+    /**
+     * @dev ERC1271 signature validation
+     * @param _hash Hash of the data to be signed
+     * @param _signature Signature byte array associated with _hash
+     * @return magicValue 0x1626ba7e if valid, 0xffffffff if invalid
+     */
+    function isValidSignature(
+        bytes32 _hash,
+        bytes memory _signature
+    ) external view returns (bytes4 magicValue) {
+        // Recover the signer address from the signature
+        address recoveredSigner = _hash.recover(_signature);
+        
+        // Check if the recovered signer matches the owner
+        if (recoveredSigner == owner) {
+            return MAGICVALUE;
+        }
+        
+        return INVALID_SIGNATURE;
+    }
+    
+    /**
+     * @dev Allow the owner to be changed for testing
+     */
+    function changeOwner(address newOwner) external {
+        require(msg.sender == owner, "Only owner can change owner");
+        owner = newOwner;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosispay/account-kit",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "author": "cristovao.honorato@gnosis.io",
   "main": "dist/cjs/src/index.js",
   "module": "dist/esm/src/index.js",

--- a/src/entrypoints/accounts-actions/execute.ts
+++ b/src/entrypoints/accounts-actions/execute.ts
@@ -1,4 +1,4 @@
-import { AbiCoder, concat, getAddress } from "ethers";
+import { AbiCoder, concat, getAddress, zeroPadValue, toBeHex } from "ethers";
 
 import deployments from "../../deployments";
 import typedDataForModifierTransaction from "../../eip712";
@@ -49,6 +49,47 @@ function encodeDelayModTransaction(transaction: TransactionRequest): string {
 }
 
 /**
+ * Encodes an ERC1271 signature for use with the delay modifier
+ * This implements the SignatureChecker format required by the delay module.
+ * Returns the complete final calldata ready to be sent to the delay module.
+ *
+ * Final structure: [execFromModuleCalldata] + [signature] + [salt] + [r] + [s] + [v]
+ * Where:
+ * - r = padded smart wallet address (32 bytes)
+ * - s = signature offset (32 bytes)
+ * - v = 0x00 (contract signature marker)
+ *
+ * @param signature - The ERC1271 signature to encode
+ * @param smartWalletAddress - The smart contract wallet address that created the signature
+ * @param salt - The salt used in the transaction
+ * @param execFromModuleCalldata - The original execTransactionFromModule calldata
+ * @returns The complete final calldata for the delay module transaction
+ */
+function encodeERC1271Signature(
+  signature: string,
+  smartWalletAddress: string,
+  salt: string,
+  execFromModuleCalldata: string
+): string {
+  // For ERC-1271 contract signatures in SignatureChecker:
+  // Final structure: [execFromModuleCalldata] + [signature] + [salt] + [r] + [s] + [v]
+
+  // r = padded smart wallet address (32 bytes)
+  const r = zeroPadValue(getAddress(smartWalletAddress), 32);
+
+  // s = signature offset - points to where signature starts in the final calldata
+  // This is the length of the original execFromModuleCalldata in bytes
+  const signatureOffset = (execFromModuleCalldata.length - 2) / 2;
+  const s = zeroPadValue(toBeHex(signatureOffset), 32);
+
+  // v = 0x00 (contract signature marker)
+  const v = "0x00";
+
+  // Complete final calldata: execFromModuleCalldata + signature + salt + r + s + v
+  return concat([execFromModuleCalldata, signature, salt, r, s, v]);
+}
+
+/**
  * Generates a payload that wraps a transaction, and posts it to the Delay Mod
  * queue. The populated transaction is relay ready, and does not require
  * additional signing.
@@ -96,28 +137,45 @@ export async function populateExecuteEnqueue(
  * on the Delay Modifier. This function combines the encoded transaction data
  * with the salt and signature to create a relay-ready transaction.
  *
+ * Supports both EOA and ERC1271 signatures:
+ * - If smartWalletAddress is provided: ERC1271 signature encoding
+ * - If smartWalletAddress is not provided: EOA signature (default)
+ *
  * @param parameters - Object containing account, transaction, message, and signature
- * @param parameters.account - The address of the account Safe
+ * @param parameters.account - The address of the account Safe (renamed to gpSafe for clarity)
  * @param parameters.transaction - The original transaction to be executed
  * @param parameters.message - The message object containing salt and data from typed data generation
- * @param parameters.signature - The EIP-712 signature from the account owner
+ * @param parameters.signature - The EIP-712 signature
+ * @param parameters.smartWalletAddress - Optional smart contract wallet address for ERC1271 signatures
  * @returns The complete transaction request ready for relay execution
  *
  * @example
+ * // EOA signature (default)
  * import { getTransactionRequest } from "@gnosispay/account-kit";
  *
  * const txRequest = getTransactionRequest({
- *   account: "0x<address>",
+ *   account: "0x<gp_safe_address>",
  *   transaction: { to: "0x<address>", value: 0n, data: "0x<bytes>" },
  *   message: { salt: "0x<bytes32>", data: "0x<encoded_data>" },
- *   signature: "0x<signature>"
+ *   signature: "0x<eoa_signature>"
+ * });
+ *
+ * @example
+ * // ERC1271 signature
+ * const txRequest = getTransactionRequest({
+ *   account: "0x<gp_safe_address>",
+ *   transaction: { to: "0x<address>", value: 0n, data: "0x<bytes>" },
+ *   message: { salt: "0x<bytes32>", data: "0x<encoded_data>" },
+ *   signature: "0x<erc1271_signature>",
+ *   smartWalletAddress: "0x<smart_wallet_address>"
  * });
  */
 export const getTransactionRequest = ({
-  account,
+  account: gpSafe,
   transaction,
   message,
   signature,
+  smartWalletAddress,
 }: {
   account: string;
   transaction: TransactionRequest;
@@ -126,16 +184,36 @@ export const getTransactionRequest = ({
     data: string;
   };
   signature: string;
+  smartWalletAddress?: string;
 }) => {
-  const checkSumedAccount = getAddress(account);
+  const checkSumedAccount = getAddress(gpSafe);
   const delayModAddress = predictDelayModAddress(checkSumedAccount);
   const encodedData = encodeDelayModTransaction(transaction);
 
-  return {
-    to: delayModAddress,
-    value: 0,
-    data: concat([encodedData, message.salt, signature]),
-  };
+  if (!smartWalletAddress) {
+    // EOA signature - original format
+    return {
+      to: delayModAddress,
+      value: 0,
+      data: concat([encodedData, message.salt, signature]),
+    };
+  } else {
+    // ERC1271 signature - use SignatureChecker format
+    // The encodeERC1271Signature function returns the complete final calldata
+    // Structure: [execFromModuleCalldata] + [signature] + [salt] + [r] + [s] + [v]
+    const finalCalldata = encodeERC1271Signature(
+      signature,
+      smartWalletAddress,
+      message.salt,
+      encodedData
+    );
+
+    return {
+      to: delayModAddress,
+      value: 0,
+      data: finalCalldata,
+    };
+  }
 };
 
 /**

--- a/src/entrypoints/accounts-actions/execute.ts
+++ b/src/entrypoints/accounts-actions/execute.ts
@@ -76,7 +76,6 @@ function encodeERC1271Signature(
   execFromModuleCalldata: string
 ): string {
   // For ERC-1271 contract signatures in SignatureChecker:
-  // Final structure: [execFromModuleCalldata] + [signature] + [salt] + [r] + [s] + [v]
 
   // r = padded smart wallet address (32 bytes)
   const r = zeroPadValue(getAddress(smartWalletAddress), 32);

--- a/src/entrypoints/accounts-actions/execute.ts
+++ b/src/entrypoints/accounts-actions/execute.ts
@@ -142,7 +142,7 @@ export async function populateExecuteEnqueue(
  * - If smartWalletAddress is not provided: EOA signature (default)
  *
  * @param parameters - Object containing account, transaction, message, and signature
- * @param parameters.account - The address of the account Safe (renamed to gpSafe for clarity)
+ * @param parameters.account - The address of the account Safe
  * @param parameters.transaction - The original transaction to be executed
  * @param parameters.message - The message object containing salt and data from typed data generation
  * @param parameters.signature - The EIP-712 signature
@@ -191,16 +191,14 @@ export const getTransactionRequest = ({
   const encodedData = encodeDelayModTransaction(transaction);
 
   if (!smartWalletAddress) {
-    // EOA signature - original format
+    // EOA signature
     return {
       to: delayModAddress,
       value: 0,
       data: concat([encodedData, message.salt, signature]),
     };
   } else {
-    // ERC1271 signature - use SignatureChecker format
-    // The encodeERC1271Signature function returns the complete final calldata
-    // Structure: [execFromModuleCalldata] + [signature] + [salt] + [r] + [s] + [v]
+    // ERC1271 signature
     const finalCalldata = encodeERC1271Signature(
       signature,
       smartWalletAddress,

--- a/src/entrypoints/accounts-actions/execute.ts
+++ b/src/entrypoints/accounts-actions/execute.ts
@@ -24,6 +24,10 @@ type EnqueueParameters = {
    * (Should be omitted, and in that case, a random salt will be generated)
    */
   salt?: string;
+  /*
+   * An optional smart contract wallet address for ERC1271 signatures
+   */
+  smartWalletAddress?: string;
 };
 
 type DispatchParameters = {
@@ -92,11 +96,13 @@ function encodeERC1271Signature(
 /**
  * Generates a payload that wraps a transaction, and posts it to the Delay Mod
  * queue. The populated transaction is relay ready, and does not require
- * additional signing.
+ * additional signing. The smartWalletAddress is optional but should be used if
+ * the account is a smart contract wallet that uses ERC1271 signatures.
  *
  * @param parameters - {@link EnqueueParameters}
  * @param transaction - {@link TransactionRequest}
  * @param sign - {@link SignTypedDataCallback}
+ * @param smartWalletAddress - {@link string}
  * @returns The signed transaction payload {@link TransactionRequest}
  *
  * @example
@@ -113,7 +119,7 @@ function encodeERC1271Signature(
  * await relayer.sendTransaction(enqueueTx);
  */
 export async function populateExecuteEnqueue(
-  { account, chainId, salt }: EnqueueParameters,
+  { account, chainId, salt, smartWalletAddress }: EnqueueParameters,
   transaction: TransactionRequest,
   sign: SignTypedDataCallback
 ): Promise<TransactionRequest> {
@@ -129,6 +135,7 @@ export async function populateExecuteEnqueue(
     transaction,
     message,
     signature,
+    smartWalletAddress,
   });
 }
 

--- a/test/execute-erc1271.spec.ts
+++ b/test/execute-erc1271.spec.ts
@@ -1,0 +1,395 @@
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { expect } from "chai";
+import hre from "hardhat";
+
+import {
+  createSetupConfig,
+  postFixture,
+  preFixture,
+} from "./test-helpers/index";
+
+import {
+  populateAccountCreation,
+  populateAccountSetup,
+  populateExecuteEnqueue,
+  getTransactionRequest,
+  generateTypedData,
+  predictAccountAddress,
+} from "../src";
+
+import { predictDelayModAddress } from "../src/parts";
+import {
+  IDelayModifier__factory,
+  ISafe__factory,
+  RealERC1271Wallet,
+} from "../typechain-types";
+
+describe("execute with ERC1271 signatures", () => {
+  before(async () => {
+    await preFixture();
+  });
+
+  after(async () => {
+    await postFixture();
+  });
+
+  async function setupAccountWithERC1271() {
+    const [owner, relayer, other] = await hre.ethers.getSigners();
+
+    // Deploy real ERC1271 wallet
+    const RealERC1271WalletFactory =
+      await hre.ethers.getContractFactory("RealERC1271Wallet");
+    const realWallet = (await RealERC1271WalletFactory.deploy(
+      owner.address
+    )) as unknown as RealERC1271Wallet;
+    const realWalletAddress = await realWallet.getAddress();
+
+    const config = createSetupConfig({
+      cooldown: 120, // 2 minutes
+      expiration: 300, // 5 minutes
+    });
+
+    const account = predictAccountAddress({ owner: owner.address });
+    const delayAddress = predictDelayModAddress(account);
+
+    // Create and setup the account
+    const creationTx = populateAccountCreation({ owner: owner.address });
+    const setupTx = await populateAccountSetup(
+      { account, owner: owner.address, chainId: 31337, nonce: 0 },
+      config,
+      ({ domain, types, message }) =>
+        owner.signTypedData(domain, types, message)
+    );
+
+    await relayer.sendTransaction(creationTx);
+    await relayer.sendTransaction(setupTx);
+
+    return {
+      account,
+      owner,
+      relayer,
+      other,
+      realWallet,
+      realWalletAddress,
+      safe: ISafe__factory.connect(account, relayer),
+      delay: IDelayModifier__factory.connect(delayAddress, relayer),
+      config,
+    };
+  }
+
+  describe("getTransactionRequest", () => {
+    it("should handle EOA signatures", async () => {
+      const { account, owner } = await loadFixture(setupAccountWithERC1271);
+
+      const transaction = {
+        to: "0x1234567890123456789012345678901234567890",
+        value: 0n,
+        data: "0x",
+      };
+
+      const { message } = generateTypedData(
+        { account, chainId: 31337 },
+        transaction
+      );
+
+      // Mock EOA signature (132 characters)
+      const eoaSignature = "0x" + "a".repeat(130);
+
+      const txRequest = getTransactionRequest({
+        account,
+        transaction,
+        message,
+        signature: eoaSignature,
+        // No smartWalletAddress = EOA processing
+      });
+
+      expect(txRequest.to).to.equal(predictDelayModAddress(account));
+      expect(txRequest.value).to.equal(0);
+      expect(txRequest.data).to.be.a("string");
+      expect(txRequest.data.startsWith("0x")).to.be.true;
+
+      // For EOA, the data should be: encodedData + salt + signature
+      const {
+        domain: testDomain,
+        types: testTypes,
+        message: testMessage,
+      } = generateTypedData({ account, chainId: 31337 }, transaction);
+
+      // Create a real signature to test with
+      const realSignature = await owner.signTypedData(
+        testDomain,
+        testTypes,
+        testMessage
+      );
+
+      const realTxRequest = getTransactionRequest({
+        account,
+        transaction,
+        message: testMessage,
+        signature: realSignature,
+        // No smartWalletAddress = EOA processing
+      });
+
+      // Validate the EOA structure: encodedData + salt + signature
+      expect(realTxRequest.data).to.include(testMessage.salt.slice(2)); // Remove 0x prefix
+
+      // The data should contain the signature
+      expect(realTxRequest.data).to.include(realSignature.slice(2)); // Remove 0x prefix
+
+      // The data should end with the signature (last 130 hex chars = 65 bytes * 2)
+      const dataWithoutPrefix = realTxRequest.data.slice(2); // Remove 0x
+      const signatureWithoutPrefix = realSignature.slice(2); // Remove 0x
+      expect(dataWithoutPrefix.endsWith(signatureWithoutPrefix)).to.be.true;
+
+      // EOA format should be shorter than ERC1271 format
+      expect(realTxRequest.data.length).to.be.lessThan(1000);
+    });
+
+    it("should handle ERC1271 signatures with smartWalletAddress", async () => {
+      const { account, realWalletAddress, owner } = await loadFixture(
+        setupAccountWithERC1271
+      );
+
+      const transaction = {
+        to: "0x1234567890123456789012345678901234567890",
+        value: 0n,
+        data: "0x",
+      };
+
+      const { message } = generateTypedData(
+        { account, chainId: 31337 },
+        transaction
+      );
+
+      // Mock ERC1271 signature (different length to distinguish from EOA)
+      const erc1271Signature = "0x" + "b".repeat(200);
+
+      const txRequest = getTransactionRequest({
+        account,
+        transaction,
+        message,
+        signature: erc1271Signature,
+        smartWalletAddress: realWalletAddress, // This triggers ERC1271 processing
+      });
+
+      expect(txRequest.to).to.equal(predictDelayModAddress(account));
+      expect(txRequest.value).to.equal(0);
+      expect(txRequest.data).to.be.a("string");
+      expect(txRequest.data.startsWith("0x")).to.be.true;
+
+      // For ERC1271, the data should be longer due to additional encoding
+      // Format: execFromModuleCalldata + signature + salt + r + s + v
+      const {
+        domain: testDomain,
+        types: testTypes,
+        message: testMessage,
+      } = generateTypedData({ account, chainId: 31337 }, transaction);
+
+      // Create a real signature to test with
+      const realSignature = await owner.signTypedData(
+        testDomain,
+        testTypes,
+        testMessage
+      );
+
+      const realERC1271TxRequest = getTransactionRequest({
+        account,
+        transaction,
+        message: testMessage,
+        signature: realSignature,
+        smartWalletAddress: realWalletAddress,
+      });
+
+      // Validate the ERC1271 structure: execFromModuleCalldata + signature + salt + r + s + v
+      // The data should contain the signature
+      expect(realERC1271TxRequest.data).to.include(realSignature.slice(2)); // Remove 0x prefix
+
+      // The data should contain the salt
+      expect(realERC1271TxRequest.data).to.include(testMessage.salt.slice(2)); // Remove 0x prefix
+
+      // The data should contain the smart wallet address (as part of r parameter)
+      const walletAddressWithoutPrefix = realWalletAddress
+        .slice(2)
+        .toLowerCase();
+      expect(realERC1271TxRequest.data.toLowerCase()).to.include(
+        walletAddressWithoutPrefix
+      );
+
+      // The data should end with the signature format: r (32 bytes) + s (32 bytes) + v (1 byte) = 65 bytes = 130 hex chars
+      const dataWithoutPrefix = realERC1271TxRequest.data.slice(2); // Remove 0x
+      // Last 130 hex chars should be the RSV signature format (r + s + v)
+      expect(dataWithoutPrefix.length).to.be.greaterThan(130);
+
+      // The last byte should be 0x00 (contract signature marker)
+      expect(realERC1271TxRequest.data.endsWith("00")).to.be.true;
+
+      // ERC1271 format should be longer than EOA format
+      expect(realERC1271TxRequest.data.length).to.be.greaterThan(400);
+    });
+  });
+
+  describe("end-to-end signature validation", () => {
+    it("should work with EOA signatures (existing functionality)", async () => {
+      const { account, owner, relayer } = await loadFixture(
+        setupAccountWithERC1271
+      );
+
+      const testTransaction = {
+        to: account, // Send to self
+        value: 0n,
+        data: "0x",
+      };
+
+      const enqueueTx = await populateExecuteEnqueue(
+        { account, chainId: 31337 },
+        testTransaction,
+        ({ domain, types, message }) =>
+          owner.signTypedData(domain, types, message)
+      );
+
+      // Should not revert - this tests the EOA path
+      await expect(relayer.sendTransaction(enqueueTx)).to.not.be.reverted;
+    });
+
+    it("should demonstrate ERC1271 contract validates signatures correctly", async () => {
+      const { realWallet, owner } = await loadFixture(setupAccountWithERC1271);
+
+      // Create a test message and sign it properly
+      const testMessage = "Hello ERC1271!";
+      const messageHash = hre.ethers.hashMessage(testMessage);
+
+      // Sign the message using the standard signMessage method
+      const signature = await owner.signMessage(testMessage);
+
+      // Verify the real wallet validates this signature correctly
+      const isValid = await realWallet.isValidSignature(messageHash, signature);
+      expect(isValid).to.equal("0x1626ba7e"); // ERC1271 magic value
+
+      // Test with an invalid signature (wrong signer)
+      const [, wrongSigner] = await hre.ethers.getSigners();
+      const wrongSignature = await wrongSigner.signMessage(testMessage);
+      const isInvalid = await realWallet.isValidSignature(
+        messageHash,
+        wrongSignature
+      );
+      expect(isInvalid).to.equal("0xffffffff"); // Invalid signature
+    });
+
+    it("should correctly format ERC1271 transactions with mock signatures", async () => {
+      const { account, realWalletAddress } = await loadFixture(
+        setupAccountWithERC1271
+      );
+
+      const testTransaction = {
+        to: "0x2222222222222222222222222222222222222222",
+        value: 50n,
+        data: "0xabcd1234",
+      };
+
+      // Generate typed data
+      const { message } = generateTypedData(
+        { account, chainId: 31337 },
+        testTransaction
+      );
+
+      // Use a mock signature for testing the encoding format
+      // In real usage, this would come from an actual ERC1271 wallet
+      const mockSignature = "0x" + "ab".repeat(65); // 65 bytes signature
+
+      // Use our SDK to create the transaction with ERC1271 support
+      const txRequest = getTransactionRequest({
+        account,
+        transaction: testTransaction,
+        message,
+        signature: mockSignature,
+        smartWalletAddress: realWalletAddress,
+      });
+
+      // Verify the transaction is properly formatted
+      expect(txRequest.to).to.equal(predictDelayModAddress(account));
+      expect(txRequest.data).to.include(mockSignature.slice(2));
+      expect(txRequest.data).to.include(
+        realWalletAddress.slice(2).toLowerCase()
+      );
+
+      // Verify the structure matches ERC1271 encoding requirements
+      expect(txRequest.data.length).to.be.greaterThan(400); // ERC1271 format is longer
+    });
+  });
+
+  describe("signature format validation", () => {
+    it("should encode ERC1271 signatures with correct structure", async () => {
+      const { account, realWalletAddress } = await loadFixture(
+        setupAccountWithERC1271
+      );
+
+      const transaction = {
+        to: "0x1111111111111111111111111111111111111111",
+        value: 123n,
+        data: "0x1234",
+      };
+
+      const { message } = generateTypedData(
+        { account, chainId: 31337 },
+        transaction
+      );
+
+      const signature = "0x" + "d".repeat(130);
+
+      const txRequest = getTransactionRequest({
+        account,
+        transaction,
+        message,
+        signature,
+        smartWalletAddress: realWalletAddress,
+      });
+
+      // The data should contain our signature
+      expect(txRequest.data).to.include(signature.slice(2)); // Remove 0x for inclusion check
+
+      // The data should contain the smart wallet address (as part of r parameter)
+      const addressWithoutPrefix = realWalletAddress.slice(2).toLowerCase();
+      expect(txRequest.data.toLowerCase()).to.include(addressWithoutPrefix);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle empty smartWalletAddress as EOA", async () => {
+      const { account } = await loadFixture(setupAccountWithERC1271);
+
+      const transaction = {
+        to: "0x1234567890123456789012345678901234567890",
+        value: 0n,
+        data: "0x",
+      };
+
+      const { message } = generateTypedData(
+        { account, chainId: 31337 },
+        transaction
+      );
+
+      const signature = "0x" + "f".repeat(130);
+
+      // Empty string should be treated as EOA
+      const txRequest1 = getTransactionRequest({
+        account,
+        transaction,
+        message,
+        signature,
+        smartWalletAddress: "", // Empty string
+      });
+
+      // Undefined should be treated as EOA
+      const txRequest2 = getTransactionRequest({
+        account,
+        transaction,
+        message,
+        signature,
+        // smartWalletAddress undefined
+      });
+
+      // Both should produce the same result (EOA format)
+      expect(txRequest1.data).to.equal(txRequest2.data);
+    });
+  });
+});


### PR DESCRIPTION
users of the account-kit should now tell the `requestTransaction` and `populateExecuteEnque` if the account they're signing with is a smart wallet by populating the `smartWallet` parameter.

If this is omitted or empty, the account will be treated as an EOA.

Some background:

I introduced a simpler way to withdraw or add/remove owners in previous PRs on the api, so that users do not need to use the account-kit.
This required the account-kit to expose some internal functions such as getTransactionRequest. This was done in this PR: https://github.com/gnosispay/account-kit/commit/2808155ba1db077e95960eb8ed4401336c67499c#diff-5ad9a8aa55c9b47951d6ebb9d12c32ed1b3378a32838354290a2516b91979e4eR36-R86

Now, what I hadn't taken into account, is that for smart accounts, the data shouldn't be encoded like this: `data: concat([encodedData, message.salt, signature])`. This part used to be done on the client side, and each app was able to create the data the way they wanted. Since we want to simplify things for partners, and do this on the api side, we need to know whether the call to be created is for a smart wallet or not. Also we need the smart wallet address in the data, to be able to verify ERC1271 signature.

So to be able to get this data, and know whether the account is a smart wallet or not, I introduced here and optional param, that will be passed to the account-kit, and it will compute the data the right way depending on the wallet.