### PR TITLE
NPM: drop NPM AUTH Token, use OIDC instead

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write  # Required for npm OIDC
     steps:
       - uses: actions/checkout@v3
 
@@ -30,8 +31,6 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
       - run: yarn --frozen-lockfile
       - run: yarn publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
       - name: Create Release
         if: "contains(github.ref, steps.package.outputs.version)" # only works if tag contains correct package.version


### PR DESCRIPTION
For some reference, NPM Trusted Publishing: https://docs.npmjs.com/trusted-publishers#how-trusted-publishing-works

Ticket: https://linear.app/gnosis-pay/issue/DOP-545/investigate-npm-trusted-publishing-for-gnosispay-packages